### PR TITLE
relationship_bit_injection: Add `buffs_to_add_if_on_active_lot`

### DIFF
--- a/tunables/relationship_bit_injection.py
+++ b/tunables/relationship_bit_injection.py
@@ -1,6 +1,8 @@
 import services
 from lot51_core.tunables.base_injection import BaseTunableInjection
 from lot51_core.utils.injection import add_affordances, inject_mapping_lists, inject_list
+
+from buffs.tunable import TunableBuffReference
 from sims4.resources import Types
 from sims4.tuning.tunable import TunableReference, TunableList, TunableSet, TunableMapping
 
@@ -21,12 +23,16 @@ class TunableRelationshipBitInjection(BaseTunableInjection):
         'super_affordances': TunableList(
             tunable=TunableReference(manager=services.get_instance_manager(Types.INTERACTION), pack_safe=True)
         ),
+        'buffs_to_add_if_on_active_lot': TunableList(
+            tunable=TunableBuffReference(pack_safe=False)
+        ),
     }
 
-    __slots__ = ('bits', 'bit_added_loot_list', 'provided_mixers', 'super_affordances',)
+    __slots__ = ('bits', 'bit_added_loot_list', 'provided_mixers', 'super_affordances', 'buffs_to_add_if_on_active_lot')
 
     def inject(self):
         for bit in self.bits:
             inject_list(bit, 'bit_added_loot_list', self.bit_added_loot_list)
             inject_mapping_lists(bit, 'provided_mixers', self.provided_mixers)
             add_affordances(bit, self.super_affordances, key='super_affordances')
+            inject_list(bit, 'buffs_to_add_if_on_active_lot', self.buffs_to_add_if_on_active_lot)


### PR DESCRIPTION
Adds an injector for the `buffs_to_add_if_on_active_lot` tunable on relationship bits. This allows for e.g. adding buffs for appropriateness to relationships, like EA's `buff_RelationshipAppropriateness_Friends` buff.
